### PR TITLE
Added features to toggle peer sharing and showing time of day

### DIFF
--- a/backup/moodle2/backup_giportfolio_stepslib.php
+++ b/backup/moodle2/backup_giportfolio_stepslib.php
@@ -39,7 +39,7 @@ class backup_giportfolio_activity_structure_step extends backup_activity_structu
                                                  array('name', 'intro', 'introformat', 'numbering', 'customtitles',
                                                       'timecreated', 'timemodified', 'collapsesubchapters', 'grade', 'printing',
                                                       'participantadd', 'chapternumber', 'publishnotification', 'notifyaddentry',
-                                                      'automaticgrading', 'skipintro', 'myactivitylink'));
+                                                      'automaticgrading', 'skipintro', 'myactivitylink', 'peersharing', 'timeofday'));
         $chapters = new backup_nested_element('chapters');
         $chapter = new backup_nested_element('chapter', array('id'),
                                              array('pagenum', 'subchapter', 'title', 'content', 'contentformat', 'hidden',

--- a/db/install.xml
+++ b/db/install.xml
@@ -19,6 +19,8 @@
         <FIELD NAME="collapsesubchapters" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="grade" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="grade"/>
         <FIELD NAME="printing" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="stores printing status"/>
+        <FIELD NAME="peersharing" TYPE="int" LENGTH="2" NOTNULL="false" DEFAULT="1" SEQUENCE="false" COMMENT="Students can share contributions with other students"/>
+        <FIELD NAME="timeofday" TYPE="int" LENGTH="2" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Dates show hour/minute of the day"/>
         <FIELD NAME="participantadd" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="particpant can add chapters"/>
         <FIELD NAME="chapternumber" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="stores the number of chapters for each giportfolio activity"/>
         <FIELD NAME="publishnotification" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="send notification on publish"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -509,5 +509,27 @@ function xmldb_giportfolio_upgrade($oldversion) {
     }
     // SYNERGY - end add new fields to database.
 
+    if ($oldversion < 2019061500) {
+    
+    	// Define field peersharing to be added to giportfolio.
+    	$table = new xmldb_table('giportfolio');
+    	$peersharing_field = new xmldb_field('peersharing', XMLDB_TYPE_INTEGER, '2', null, null, null, '1', 'notifyaddentry');
+    
+    	// Conditionally launch add field peersharing.
+    	if (!$dbman->field_exists($table, $peersharing_field)) {
+    		$dbman->add_field($table, $peersharing_field);
+    	}
+    	 
+    	// Conditionally launch add field showtimeofday.
+    	$timeofday_field = new xmldb_field('timeofday', XMLDB_TYPE_INTEGER, '2', null, null, null, '1', 'notifyaddentry');
+    	if (!$dbman->field_exists($table, $timeofday_field)) {
+    		$dbman->add_field($table, $timeofday_field);
+    	}
+    	
+    	// Giportfolio savepoint reached.
+    	upgrade_mod_savepoint(true, 2019061500, 'giportfolio');
+    }
+    
+    
     return true;
 }

--- a/editcontribution_form.php
+++ b/editcontribution_form.php
@@ -49,6 +49,7 @@ class mod_giportfolio_contribution_edit_form extends moodleform {
 
         $opts = array(0 => get_string('show'), 1 => get_string('hide'));
         $mform->addElement('select', 'hidden', get_string('visibility', 'giportfolio'), $opts, 0);
+        $mform->addHelpButton('hidden', 'visibilityexplain', 'giportfolio');
 
         $mform->addElement('editor', 'content_editor', get_string('content', 'mod_giportfolio'), null, $editoroptions);
         $mform->addRule('content_editor', get_string('required'), 'required', null, 'client');

--- a/lang/en/giportfolio.php
+++ b/lang/en/giportfolio.php
@@ -91,6 +91,7 @@ $string['giportfolio:viewhiddenchapters'] = 'View hidden portfolio chapters';
 $string['giportfolioof'] = 'Portfolio Of: ';
 $string['gradesupdated'] = '...Grades updated...';
 $string['gradeupdated'] = 'Grade Updated ';
+$string['hide'] = 'Hide your contribution from everyone, including faculty';
 $string['hideshared'] = 'Hide other students\' contributions';
 $string['insertgrade'] = 'Grade Portfolio';
 $string['klassenbuchtrainer'] = 'Klassenbuch trainer mode';
@@ -136,6 +137,8 @@ $string['optionalsettings'] = 'Optional settings';
 $string['page-mod-giportfolio-x'] = 'Any portfolio module page';
 $string['pagesize'] = 'Submissions shown per page';
 $string['participantadd'] = 'Participants can add Chapters';
+$string['peersharing'] = 'Participants can share contributions with other participants';
+$string['peersharing_help'] = 'If enabled, participants can share contributions with others';
 $string['pluginadministration'] = 'Portfolio administration';
 $string['pluginname'] = 'Portfolio';
 $string['printing'] = 'Disable Printing';
@@ -148,7 +151,9 @@ $string['quickgrade'] = 'Allow quick grading';
 $string['quickgrade_help'] = 'If enabled, multiple assignments can be graded on one page. Add grades and comments then click the "Save all my feedback" button to save all changes for that page.';
 $string['saveallfeedback'] = 'Save all';
 $string['share'] = 'Share with other students';
+$string['show'] = 'Show your contribution to faculty only, not students';
 $string['showshared'] = 'Show other students\' contributions';
+$string['showtimeofday'] = 'Show time of day on dates';
 $string['noshared'] = 'No contributions from other students';
 $string['sincelastlogin'] = 'Updated since your last login';
 $string['skipintro'] = 'Students skip intro page';
@@ -173,3 +178,8 @@ $string['view'] = 'View';
 $string['viewgiportfolio'] = 'View Portfolio:  ';
 $string['viewtemplate'] = 'View/Edit portfolio template';
 $string['visibility'] = 'Visibility';
+$string['visibilityexplain'] = 'setting visibility for the contribution';
+$string['visibilityexplain_help'] = '
+* Show - contribution is visible to non-students
+* Hide - contribution is visible only to yourself
+';

--- a/lang/en/giportfolio.php
+++ b/lang/en/giportfolio.php
@@ -98,6 +98,7 @@ $string['klassenbuchtrainer'] = 'Klassenbuch trainer mode';
 $string['klassenbuchtrainer_help'] = 'Enabling this will display the Klassenbuch \'class plan\' feature within each chapter of the portfolio.<br>
 This feature can only be selected when the activity is first created.';
 $string['lastgrade'] = 'Graded ';
+$string['lastmodified'] = 'Last Modified:  ';
 $string['lastupdated'] = 'Last Updated:  ';
 $string['messageprovider:addentry'] = 'Notification of new Portfolio entries';
 $string['modulename'] = 'Portfolio';

--- a/lib.php
+++ b/lib.php
@@ -521,7 +521,7 @@ function giportfolio_extend_settings_navigation(settings_navigation $settingsnav
         $gradeconsole = get_string('studentgiportfolio', 'mod_giportfolio');
         $url = new moodle_url('/mod/giportfolio/submissions.php', array('id' => $params['id']));
         $giportfolionode->add($gradeconsole, $url, navigation_node::TYPE_SETTING, null, null,
-                              new pix_icon('console', '', 'giportfoliotool_print', array('class' => 'icon')));
+                              new image_url('console', '', 'giportfoliotool_print', array('class' => 'icon')));
     }
     // Add publish- unpublish links only if the user has at least one contribution.
 
@@ -538,14 +538,14 @@ function giportfolio_extend_settings_navigation(settings_navigation $settingsnav
             // Open as new window.
             $action = new action_link($url, get_string('exportpdf', 'mod_giportfolio'), new popup_action('click', $url));
             $giportfolionode->add(get_string('exportpdf', 'mod_giportfolio'), $action, navigation_node::TYPE_SETTING, null, null,
-                                  new pix_icon('pdf', '', 'giportfoliotool_print', array('class' => 'icon')));
+                                  new image_url('pdf', '', 'giportfoliotool_print', array('class' => 'icon')));
 
             // SYNERGY LEARNING - Export as zip option.
             $url = new moodle_url('/mod/giportfolio/tool/export/zipgiportfolio.php', array(
                 'id' => $params['id']
             )); // Add zip export link.
             $giportfolionode->add(get_string('exportzip', 'mod_giportfolio'), $url, navigation_node::TYPE_SETTING, null, null,
-                                  new pix_icon('zip', '', 'giportfoliotool_export', array('class' => 'icon')));
+                                  new image_url('zip', '', 'giportfoliotool_export', array('class' => 'icon')));
             // END SYNERGY LEARNING - Export as zip option.
         }
 
@@ -569,7 +569,7 @@ function giportfolio_extend_settings_navigation(settings_navigation $settingsnav
                                                                            'sesskey' => sesskey(), 'useredit' => $edit
                                                                       ));
         $giportfolionode->add($tocedit, $url, navigation_node::TYPE_SETTING, null, null,
-                              new pix_icon('editstatus', '', 'giportfoliotool_print', array('class' => 'icon')));
+                              new image_url('editstatus', '', 'giportfoliotool_print', array('class' => 'icon')));
     }
 
     // SYNERGY.
@@ -622,7 +622,7 @@ function giportfolio_print_attachments($contribution, $cm, $type = null, $align 
         foreach ($files as $file) {
             $filename = $file->get_filename();
             $mimetype = $file->get_mimetype();
-            $iconimage = '<img src="'.$OUTPUT->pix_url(file_mimetype_icon($mimetype)).'" class="icon" alt="'.$mimetype.'" />';
+            $iconimage = '<img src="'.$OUTPUT->image_url(file_mimetype_icon($mimetype)).'" class="icon" alt="'.$mimetype.'" />';
             $path = moodle_url::make_pluginfile_url($file->get_contextid(), $file->get_component(), $file->get_filearea(),
                                                     $file->get_itemid(), $file->get_filepath(), $file->get_filename());
 

--- a/locallib.php
+++ b/locallib.php
@@ -433,31 +433,31 @@ function giportfolio_get_toc($chapters, $chapter, $giportfolio, $cm, $edit) {
             if ($i != 1) {
                 $toc .= ' <a title="'.get_string('up').'" href="move.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;up=1&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_url('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
+                    <img src="'.$OUTPUT->pix_icon('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
             }
             if ($i != count($chapters)) {
                 $toc .= ' <a title="'.get_string('down').'" href="move.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;up=0&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_url('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
+                    <img src="'.$OUTPUT->pix_icon('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
             }
             $toc .= ' <a title="'.get_string('edit').'" href="edit.php?cmid='.$cm->id.'&amp;id='.$ch->id.'">
-            <img src="'.$OUTPUT->pix_url('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
+            <img src="'.$OUTPUT->pix_icon('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
             $toc .= ' <a title="'.get_string('delete').'" href="delete.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                 '&amp;sesskey='.$USER->sesskey.'">
-                <img src="'.$OUTPUT->pix_url('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
+                <img src="'.$OUTPUT->pix_icon('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
             if ($ch->hidden) {
                 $toc .= ' <a title="'.get_string('show').'" href="show.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_url('t/show').'" class="iconsmall" alt="'.get_string('show').'" /></a>';
+                    <img src="'.$OUTPUT->pix_icon('t/show').'" class="iconsmall" alt="'.get_string('show').'" /></a>';
             } else {
                 $toc .= ' <a title="'.get_string('hide').'" href="show.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_url('t/hide').'" class="iconsmall" alt="'.get_string('hide').'" /></a>';
+                    <img src="'.$OUTPUT->pix_icon('t/hide').'" class="iconsmall" alt="'.get_string('hide').'" /></a>';
             }
             // Synergy  only if the giportfolio activity has not yet contributions.
             $toc .= ' <a title="'.get_string('addafter', 'mod_giportfolio').'" href="edit.php?cmid='.$cm->id.
                 '&amp;pagenum='.$ch->pagenum.'&amp;subchapter='.$ch->subchapter.'">
-                <img src="'.$OUTPUT->pix_url('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
+                <img src="'.$OUTPUT->pix_icon('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
                 get_string('addafter', 'mod_giportfolio').'" /></a>';
             $toc .= (!$ch->subchapter) ? '<ul>' : '</li>';
             $first = 0;
@@ -630,26 +630,26 @@ function giportfolio_get_usertoc($chapters, $chapter, $giportfolio, $cm, $edit, 
                     if (!giportfolio_get_first_userchapter($giportfolio->id, $ch->id, $userid)) {
                         $toc .= ' <a title="'.get_string('up').'" href="moveuserchapter.php?id='.$cm->id.
                             '&amp;chapterid='.$ch->id.'&amp;up=1&amp;sesskey='.$USER->sesskey.'">
-                            <img src="'.$OUTPUT->pix_url('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
+                            <img src="'.$OUTPUT->pix_icon('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
 
                     }
                 }
                 if ($i != count($chapters)) {
                     $toc .= ' <a title="'.get_string('down').'" href="moveuserchapter.php?id='.$cm->id.
                         '&amp;chapterid='.$ch->id.'&amp;up=0&amp;sesskey='.$USER->sesskey.'">
-                        <img src="'.$OUTPUT->pix_url('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
+                        <img src="'.$OUTPUT->pix_icon('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
                 }
             }
 
             if (giportfolio_check_user_chapter($ch, $userid)) {
                 $toc .= ' <a title="'.get_string('edit').'" href="editstudent.php?cmid='.$cm->id.'&amp;id='.$ch->id.'">
-                <img src="'.$OUTPUT->pix_url('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
+                <img src="'.$OUTPUT->pix_icon('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
             }
 
             if (giportfolio_check_user_chapter($ch, $userid)) {
                 $toc .= ' <a title="'.get_string('delete').'" href="deleteuserchapter.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_url('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
+                    <img src="'.$OUTPUT->pix_icon('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
             }
 
             if (giportfolio_check_user_chapter($ch, $userid) ||
@@ -657,7 +657,7 @@ function giportfolio_get_usertoc($chapters, $chapter, $giportfolio, $cm, $edit, 
 
                 $toc .= ' <a title="'.get_string('addafter', 'mod_giportfolio').'" href="editstudent.php?cmid='.$cm->id.
                     '&amp;pagenum='.$ch->pagenum.'&amp;subchapter='.$ch->subchapter.'">
-                    <img src="'.$OUTPUT->pix_url('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
+                    <img src="'.$OUTPUT->pix_icon('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
                     get_string('addafter', 'mod_giportfolio').'" /></a>';
             }
             $toc .= (!$ch->subchapter) ? '<ul>' : '</li>';

--- a/locallib.php
+++ b/locallib.php
@@ -433,31 +433,31 @@ function giportfolio_get_toc($chapters, $chapter, $giportfolio, $cm, $edit) {
             if ($i != 1) {
                 $toc .= ' <a title="'.get_string('up').'" href="move.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;up=1&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_icon('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
+                    <img src="'.$OUTPUT->image_url('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
             }
             if ($i != count($chapters)) {
                 $toc .= ' <a title="'.get_string('down').'" href="move.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;up=0&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_icon('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
+                    <img src="'.$OUTPUT->image_url('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
             }
             $toc .= ' <a title="'.get_string('edit').'" href="edit.php?cmid='.$cm->id.'&amp;id='.$ch->id.'">
-            <img src="'.$OUTPUT->pix_icon('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
+            <img src="'.$OUTPUT->image_url('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
             $toc .= ' <a title="'.get_string('delete').'" href="delete.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                 '&amp;sesskey='.$USER->sesskey.'">
-                <img src="'.$OUTPUT->pix_icon('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
+                <img src="'.$OUTPUT->image_url('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
             if ($ch->hidden) {
                 $toc .= ' <a title="'.get_string('show').'" href="show.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_icon('t/show').'" class="iconsmall" alt="'.get_string('show').'" /></a>';
+                    <img src="'.$OUTPUT->image_url('t/show').'" class="iconsmall" alt="'.get_string('show').'" /></a>';
             } else {
                 $toc .= ' <a title="'.get_string('hide').'" href="show.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_icon('t/hide').'" class="iconsmall" alt="'.get_string('hide').'" /></a>';
+                    <img src="'.$OUTPUT->image_url('t/hide').'" class="iconsmall" alt="'.get_string('hide').'" /></a>';
             }
             // Synergy  only if the giportfolio activity has not yet contributions.
             $toc .= ' <a title="'.get_string('addafter', 'mod_giportfolio').'" href="edit.php?cmid='.$cm->id.
                 '&amp;pagenum='.$ch->pagenum.'&amp;subchapter='.$ch->subchapter.'">
-                <img src="'.$OUTPUT->pix_icon('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
+                <img src="'.$OUTPUT->image_url('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
                 get_string('addafter', 'mod_giportfolio').'" /></a>';
             $toc .= (!$ch->subchapter) ? '<ul>' : '</li>';
             $first = 0;
@@ -630,26 +630,26 @@ function giportfolio_get_usertoc($chapters, $chapter, $giportfolio, $cm, $edit, 
                     if (!giportfolio_get_first_userchapter($giportfolio->id, $ch->id, $userid)) {
                         $toc .= ' <a title="'.get_string('up').'" href="moveuserchapter.php?id='.$cm->id.
                             '&amp;chapterid='.$ch->id.'&amp;up=1&amp;sesskey='.$USER->sesskey.'">
-                            <img src="'.$OUTPUT->pix_icon('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
+                            <img src="'.$OUTPUT->image_url('t/up').'" class="iconsmall" alt="'.get_string('up').'" /></a>';
 
                     }
                 }
                 if ($i != count($chapters)) {
                     $toc .= ' <a title="'.get_string('down').'" href="moveuserchapter.php?id='.$cm->id.
                         '&amp;chapterid='.$ch->id.'&amp;up=0&amp;sesskey='.$USER->sesskey.'">
-                        <img src="'.$OUTPUT->pix_icon('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
+                        <img src="'.$OUTPUT->image_url('t/down').'" class="iconsmall" alt="'.get_string('down').'" /></a>';
                 }
             }
 
             if (giportfolio_check_user_chapter($ch, $userid)) {
                 $toc .= ' <a title="'.get_string('edit').'" href="editstudent.php?cmid='.$cm->id.'&amp;id='.$ch->id.'">
-                <img src="'.$OUTPUT->pix_icon('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
+                <img src="'.$OUTPUT->image_url('t/edit').'" class="iconsmall" alt="'.get_string('edit').'" /></a>';
             }
 
             if (giportfolio_check_user_chapter($ch, $userid)) {
                 $toc .= ' <a title="'.get_string('delete').'" href="deleteuserchapter.php?id='.$cm->id.'&amp;chapterid='.$ch->id.
                     '&amp;sesskey='.$USER->sesskey.'">
-                    <img src="'.$OUTPUT->pix_icon('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
+                    <img src="'.$OUTPUT->image_url('t/delete').'" class="iconsmall" alt="'.get_string('delete').'" /></a>';
             }
 
             if (giportfolio_check_user_chapter($ch, $userid) ||
@@ -657,7 +657,7 @@ function giportfolio_get_usertoc($chapters, $chapter, $giportfolio, $cm, $edit, 
 
                 $toc .= ' <a title="'.get_string('addafter', 'mod_giportfolio').'" href="editstudent.php?cmid='.$cm->id.
                     '&amp;pagenum='.$ch->pagenum.'&amp;subchapter='.$ch->subchapter.'">
-                    <img src="'.$OUTPUT->pix_icon('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
+                    <img src="'.$OUTPUT->image_url('add', 'mod_giportfolio').'" class="iconsmall" alt="'.
                     get_string('addafter', 'mod_giportfolio').'" /></a>';
             }
             $toc .= (!$ch->subchapter) ? '<ul>' : '</li>';

--- a/mod_form.php
+++ b/mod_form.php
@@ -82,6 +82,15 @@ class mod_giportfolio_mod_form extends moodleform_mod {
 
         // SYNERGY - add collapsesubchapters option to settings.
         $mform->addElement('selectyesno', 'collapsesubchapters', get_string('collapsesubchapters', 'giportfolio'));
+        
+        // add peersharing option to settings
+        $mform->addElement('selectyesno', 'peersharing', get_string('peersharing', 'giportfolio'));
+        $mform->setDefault('peersharing', 1);
+        
+        // add display hour/minute to dates
+        $mform->addElement('selectyesno', 'timeofday', get_string('showtimeofday', 'giportfolio'));
+        $mform->setDefault('timeofday', 0);
+        
         $mform->addElement('selectyesno', 'participantadd', get_string('participantadd', 'giportfolio'));
         $mform->setDefault('participantadd', 1);
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2016112100; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2019061500; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2014051200; // Requires this Moodle version (2.7).
 $plugin->cron      = 0;          // Period for cron to check this module (secs).
 $plugin->component = 'mod_giportfolio'; // Full name of the plugin (used for diagnostics).

--- a/viewcontribute.php
+++ b/viewcontribute.php
@@ -224,7 +224,10 @@ if ($contriblist) {
             $contribtitle = file_rewrite_pluginfile_urls($contrib->title, 'pluginfile.php', $context->id, 'mod_giportfolio',
                                                          'contribution', $contrib->id);
             echo '<strong>'.$contribtitle.'</strong></br>';
-            echo date('l jS F Y', $contrib->timemodified);
+            echo date('l jS F Y'.($giportfolio->timeofday ? ' h:i A' : ''), $contrib->timecreated);
+            if($contrib->timecreated !== $contrib->timemodified) {
+            	echo '<br/><i>Last modified on '.date('l jS F Y'.($giportfolio->timeofday ? ' \a\t h:i A' : ''), $contrib->timemodified).'</i>';
+            }
             echo '</br></br>';
             $contribtext = file_rewrite_pluginfile_urls($contrib->content, 'pluginfile.php', $context->id, 'mod_giportfolio',
                                                         'contribution', $contrib->id);

--- a/viewcontribute.php
+++ b/viewcontribute.php
@@ -142,15 +142,15 @@ $chnavigation = '';
 if ($previd) {
     $chnavigation .= '<a title="'.get_string('navprev', 'giportfolio').'" href="viewcontribute.php?id='.$cm->id.
         '&amp;chapterid='.$previd.'&amp;userid='.$userid.'">
-        <img src="'.$OUTPUT->pix_url('nav_prev', 'mod_giportfolio').'" class="bigicon" alt="'.
+        <img src="'.$OUTPUT->image_url('nav_prev', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navprev', 'giportfolio').'"/></a>';
 } else {
-    $chnavigation .= '<img src="'.$OUTPUT->pix_url('nav_prev_dis', 'mod_giportfolio').'" class="bigicon" alt="" />';
+	$chnavigation .= '<img src="'.$OUTPUT->image_url('nav_prev_dis', 'mod_giportfolio').'" class="bigicon" alt="" />';
 }
 if ($nextid) {
     $chnavigation .= '<a title="'.get_string('navnext', 'giportfolio').'" href="viewcontribute.php?id='.$cm->id.
         '&amp;chapterid='.$nextid.'&amp;userid='.$userid.'">
-        <img src="'.$OUTPUT->pix_url('nav_next', 'mod_giportfolio').'" class="bigicon" alt="'.
+        <img src="'.$OUTPUT->image_url('nav_next', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navnext', 'giportfolio').'" /></a>';
 } else {
     $sec = '';
@@ -163,7 +163,7 @@ if ($nextid) {
         $returnurl = "$CFG->wwwroot/mod/giportfolio/submissions.php?id=$cm->id";
     }
     $chnavigation .= '<a title="'.get_string('navexit', 'giportfolio').'" href="'.$returnurl.'">
-    <img src="'.$OUTPUT->pix_url('nav_exit', 'mod_giportfolio').'" class="bigicon" alt="'.
+    <img src="'.$OUTPUT->image_url('nav_exit', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navexit', 'giportfolio').'" /></a>';
 
     // We are cheating a bit here, viewing the last page means user has viewed the whole giportfolio.
@@ -226,7 +226,7 @@ if ($contriblist) {
             echo '<strong>'.$contribtitle.'</strong></br>';
             echo date('l jS F Y'.($giportfolio->timeofday ? ' h:i A' : ''), $contrib->timecreated);
             if($contrib->timecreated !== $contrib->timemodified) {
-            	echo '<br/><i>Last modified on '.date('l jS F Y'.($giportfolio->timeofday ? ' \a\t h:i A' : ''), $contrib->timemodified).'</i>';
+            	echo '<br/><i>'.get_string('lastmodified', 'mod_giportfolio').date('l jS F Y'.($giportfolio->timeofday ? ' h:i A' : ''), $contrib->timemodified).'</i>';
             }
             echo '</br></br>';
             $contribtext = file_rewrite_pluginfile_urls($contrib->content, 'pluginfile.php', $context->id, 'mod_giportfolio',

--- a/viewgiportfolio.php
+++ b/viewgiportfolio.php
@@ -169,15 +169,15 @@ $chnavigation = '';
 if ($previd) {
     $chnavigation .= '<a title="'.get_string('navprev', 'giportfolio').'" href="viewgiportfolio.php?id='.$cm->id.
         '&amp;chapterid='.$previd.'">
-        <img src="'.$OUTPUT->pix_url('nav_prev', 'mod_giportfolio').'" class="bigicon" alt="'.
+        <img src="'.$OUTPUT->pix_icon('nav_prev', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navprev', 'giportfolio').'"/></a>';
 } else {
-    $chnavigation .= '<img src="'.$OUTPUT->pix_url('nav_prev_dis', 'mod_giportfolio').'" class="bigicon" alt="" />';
+    $chnavigation .= '<img src="'.$OUTPUT->pix_icon('nav_prev_dis', 'mod_giportfolio').'" class="bigicon" alt="" />';
 }
 if ($nextid) {
     $chnavigation .= '<a title="'.get_string('navnext', 'giportfolio').'" href="viewgiportfolio.php?id='.$cm->id.
         '&amp;chapterid='.$nextid.'">
-        <img src="'.$OUTPUT->pix_url('nav_next', 'mod_giportfolio').'" class="bigicon" alt="'.
+        <img src="'.$OUTPUT->pix_icon('nav_next', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navnext', 'giportfolio').'" /></a>';
 } else {
     $sec = '';
@@ -190,7 +190,7 @@ if ($nextid) {
         $returnurl = "$CFG->wwwroot/course/view.php?id=$course->id#section-$sec";
     }
     $chnavigation .= '<a title="'.get_string('navexit', 'giportfolio').'" href="'.$returnurl.'">
-    <img src="'.$OUTPUT->pix_url('nav_exit', 'mod_giportfolio').'" class="bigicon" alt="'.
+    <img src="'.$OUTPUT->pix_icon('nav_exit', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navexit', 'giportfolio').'" /></a>';
 
     // We are cheating a bit here, viewing the last page means user has viewed the whole giportfolio.
@@ -358,7 +358,7 @@ if ($contriblist) {
         $cout .= $userfullname.'<strong>'.format_string($contrib->title).'</strong>  '.implode(' ', $actions).'<br>';
         $cout .= date('l jS F Y'.($giportfolio->timeofday ? ' \a\t h:i A' : ''), $contrib->timecreated);
         if($contrib->timecreated !== $contrib->timemodified) {
-        	$cout .= '<br/><i>Last modified on '.date('l jS F Y'.($giportfolio->timeofday ? ' \a\t h:i A' : ''), $contrib->timemodified).'</i>';
+        	$cout .= '<br/><i>'.get_string('lastmodified', 'mod_giportfolio').date('l jS F Y'.($giportfolio->timeofday ? ' h:i A' : ''), $contrib->timemodified).'</i>';
         }
         
         $cout .= '<br><br>';

--- a/viewgiportfolio.php
+++ b/viewgiportfolio.php
@@ -169,15 +169,15 @@ $chnavigation = '';
 if ($previd) {
     $chnavigation .= '<a title="'.get_string('navprev', 'giportfolio').'" href="viewgiportfolio.php?id='.$cm->id.
         '&amp;chapterid='.$previd.'">
-        <img src="'.$OUTPUT->pix_icon('nav_prev', 'mod_giportfolio').'" class="bigicon" alt="'.
+        <img src="'.$OUTPUT->image_url('nav_prev', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navprev', 'giportfolio').'"/></a>';
 } else {
-    $chnavigation .= '<img src="'.$OUTPUT->pix_icon('nav_prev_dis', 'mod_giportfolio').'" class="bigicon" alt="" />';
+    $chnavigation .= '<img src="'.$OUTPUT->image_url('nav_prev_dis', 'mod_giportfolio').'" class="bigicon" alt="" />';
 }
 if ($nextid) {
     $chnavigation .= '<a title="'.get_string('navnext', 'giportfolio').'" href="viewgiportfolio.php?id='.$cm->id.
         '&amp;chapterid='.$nextid.'">
-        <img src="'.$OUTPUT->pix_icon('nav_next', 'mod_giportfolio').'" class="bigicon" alt="'.
+        <img src="'.$OUTPUT->image_url('nav_next', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navnext', 'giportfolio').'" /></a>';
 } else {
     $sec = '';
@@ -190,7 +190,7 @@ if ($nextid) {
         $returnurl = "$CFG->wwwroot/course/view.php?id=$course->id#section-$sec";
     }
     $chnavigation .= '<a title="'.get_string('navexit', 'giportfolio').'" href="'.$returnurl.'">
-    <img src="'.$OUTPUT->pix_icon('nav_exit', 'mod_giportfolio').'" class="bigicon" alt="'.
+    <img src="'.$OUTPUT->image_url('nav_exit', 'mod_giportfolio').'" class="bigicon" alt="'.
         get_string('navexit', 'giportfolio').'" /></a>';
 
     // We are cheating a bit here, viewing the last page means user has viewed the whole giportfolio.
@@ -317,19 +317,19 @@ if ($contriblist) {
                                       array('id' => $cm->id, 'contributionid' => $contrib->id, 'chapterid' => $contrib->chapterid));
 
             $editurl = new moodle_url($baseurl);
-            $editicon = $OUTPUT->pix_icon('t/edit', get_string('edit'));
+            $editicon = $OUTPUT->image_url('t/edit', get_string('edit'));
             $editicon = html_writer::link($editurl, $editicon);
 
             $delurl = new moodle_url($baseurl, array('action' => 'delete'));
-            $delicon = $OUTPUT->pix_icon('t/delete', get_string('delete'));
+            $delicon = $OUTPUT->image_url('t/delete', get_string('delete'));
             $delicon = html_writer::link($delurl, $delicon);
 
             if ($contrib->hidden) {
                 $showurl = new moodle_url($baseurl, array('action' => 'show', 'sesskey' => sesskey()));
-                $showicon = $OUTPUT->pix_icon('t/show', get_string('show', 'mod_giportfolio'));
+                $showicon = $OUTPUT->image_url('t/show', get_string('show', 'mod_giportfolio'));
             } else {
                 $showurl = new moodle_url($baseurl, array('action' => 'hide', 'sesskey' => sesskey()));
-                $showicon = $OUTPUT->pix_icon('t/hide', get_string('hide', 'mod_giportfolio'));
+                $showicon = $OUTPUT->image_url('t/hide', get_string('hide', 'mod_giportfolio'));
             }
             $showicon = html_writer::link($showurl, $showicon);
 
@@ -337,10 +337,10 @@ if ($contriblist) {
             if (!$isuserchapter && $giportfolio->peersharing) { // Only for chapters without a userid and if peersharing is enabled.
                 if ($contrib->shared) {
                     $shareurl = new moodle_url($baseurl, array('action' => 'unshare', 'sesskey' => sesskey()));
-                    $shareicon = $OUTPUT->pix_icon('unshare', get_string('unshare', 'mod_giportfolio'), 'mod_giportfolio');
+                    $shareicon = $OUTPUT->image_url('unshare', get_string('unshare', 'mod_giportfolio'), 'mod_giportfolio');
                 } else {
                     $shareurl = new moodle_url($baseurl, array('action' => 'share', 'sesskey' => sesskey()));
-                    $shareicon = $OUTPUT->pix_icon('share', get_string('share', 'mod_giportfolio'), 'mod_giportfolio');
+                    $shareicon = $OUTPUT->image_url('share', get_string('share', 'mod_giportfolio'), 'mod_giportfolio');
                 }
                 $shareicon = html_writer::link($shareurl, $shareicon);
             }


### PR DESCRIPTION
These changes add two new fields to the giportfolio: peersharing and timeofday.

peersharing is used to control the ability of learners to share portfolio entries to the "public". This was requested in Issue #7 . I also added code to clarify what it means to show an entry because many students often hid their entries, not knowing that they are hiding their entries from the graders/faculty. By default, this is on to provide backwards compatibility.

timeofday is used to control whether the time of day (hours/minutes) is shown on a post. This is a personal need because we have deadlines for our learners to submit entries and we cannot tell when this happens. By default, this is off to provide backwards compatibility.