### PR TITLE
establish PHP 8 compatibility

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -78,7 +78,7 @@ function giportfolio_add_instance($giportfolio, $mform) {
 
     if ($giportfolio) {
         $addcontent = get_string('addcontent', 'mod_giportfolio');
-        
+
         for ($ch = 0; $ch < $giportfolio->chapternumber; $ch++) {
             $initchapter = new stdClass();
             $initchapter->giportfolioid = $giportfolio->id;
@@ -334,7 +334,7 @@ function giportfolio_grade_item_update($giportfolio, $grades = null) {
     global $CFG;
     require_once($CFG->libdir.'/gradelib.php');
 
-    if (array_key_exists('cmidnumber', $giportfolio)) { // May not be always present.
+    if (property_exists($giportfolio, 'cmidnumber')) { // May not be always present.
         $params = array('itemname' => $giportfolio->name, 'idnumber' => $giportfolio->cmidnumber);
     } else {
         $params = array('itemname' => $giportfolio->name);

--- a/mod_form.php
+++ b/mod_form.php
@@ -82,20 +82,20 @@ class mod_giportfolio_mod_form extends moodleform_mod {
 
         // SYNERGY - add collapsesubchapters option to settings.
         $mform->addElement('selectyesno', 'collapsesubchapters', get_string('collapsesubchapters', 'giportfolio'));
-        
+
         // add peersharing option to settings
         $mform->addElement('selectyesno', 'peersharing', get_string('peersharing', 'giportfolio'));
         $mform->setDefault('peersharing', 1);
-        
+
         // add display hour/minute to dates
         $mform->addElement('selectyesno', 'timeofday', get_string('showtimeofday', 'giportfolio'));
         $mform->setDefault('timeofday', 0);
-        
+
         // add display outline option to settings
         $mform->addElement('selectyesno', 'displayoutline', get_string('displayoutline', 'giportfolio'));
         $mform->addHelpButton('displayoutline', 'displayoutline', 'mod_giportfolio');
         $mform->setDefault('displayoutline', 1);
-        
+
         $mform->addElement('selectyesno', 'participantadd', get_string('participantadd', 'giportfolio'));
         $mform->setDefault('participantadd', 1);
 
@@ -128,7 +128,7 @@ class mod_giportfolio_mod_form extends moodleform_mod {
             $mform->setDefault('klassenbuchtrainer', 0);
         } else {
             $mform->addElement('hidden', 'klassenbuchtrainer', 0);
-            $mform->setType('klassenbuchtrainer', 0);
+            $mform->setType('klassenbuchtrainer', PARAM_RAW);
         }
 
         $this->standard_grading_coursemodule_elements();


### PR DESCRIPTION
Hey there,

I was checking this plugin out today in regards to Moodle 4 compatibility, and noticed that it did not jive with PHP 8 in a few spots.
This patch fixes those.

I click-tested the plugin a bit, and seems to work as intended otherwise.

Please have a look and merge if it passes muster. 

As an aside - any chance we can get a new release of this plugin soon? The Moodle plugins directory still lists a 2016 version as the latest. 

Thanks!
