### PR TITLE
fix regex syntax in mod form

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -105,7 +105,7 @@ class mod_giportfolio_mod_form extends moodleform_mod {
         $mform->setType('chapternumber', PARAM_INT);
         $mform->addRule('chapternumber', 'must be numeric', 'numeric', null, 'client');
         $mform->addRule('chapternumber', 'add valid number', 'nonzero', null, 'client');
-        $mform->addRule('chapternumber', 'add positive number', 'regex', '|^[1-9][0-9]*$|', 'client'); // Positive number.
+        $mform->addRule('chapternumber', 'add positive number', 'regex', '/^[1-9][0-9]*$/', 'client'); // Positive number.
 
         $mform->addElement('checkbox', 'publishnotification', get_string('publishnotification', 'giportfolio'));
         $mform->setDefault('publishnotification', 0);


### PR DESCRIPTION
Hello,
The mod form sections for "Grade", "Common Module settings" and others were not working due to this incorrect regex syntax.
This commit fix this erros and now the module can be used with Moodle 4.x