### PR TITLE
get_extra_user_fields and get_user_field_name are deprecated in Moodle 4.3

### DIFF
--- a/submissions.php
+++ b/submissions.php
@@ -140,13 +140,21 @@ foreach ($allusers as $user) {
 $listusersids = "'".implode("', '", $alluserids)."'";
 // Generate table.
 
-$extrafields = get_extra_user_fields($context);
+if (class_exists(\core_user\fields::class)) {
+    $extrafields = \core_user\fields::get_identity_fields($context);
+} else {
+    $extrafields = get_extra_user_fields($context);
+}
 $tablecolumns = array_merge(array('picture', 'fullname'), $extrafields,
                             array('lastupdate', 'viewgiportfolio', 'grade', 'feedback'));
 
 $extrafieldnames = array();
 foreach ($extrafields as $field) {
-    $extrafieldnames[] = get_user_field_name($field);
+    if (class_exists(\core_user\fields::class)) {
+        $extrafieldnames[] = \core_user\fields::get_display_name($field);
+    } else {
+        $extrafieldnames[] = get_user_field_name($field);
+    }
 }
 $tableheaders = array_merge(
     array('', get_string('fullnameuser')),

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020032200; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2024100700; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2017051500; // Requires this Moodle version (2.7).
 $plugin->cron      = 0;          // Period for cron to check this module (secs).
 $plugin->component = 'mod_giportfolio'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = "3.3+ (2020032200)"; // User-friendly version number.
+$plugin->release   = "3.3+ (2024100700)"; // User-friendly version number.


### PR DESCRIPTION
use \core_user\fields::get_identity_fields and \core_user\fields::get_display_name instead 
based on the work of danielneis